### PR TITLE
Stop deleting dist when we don't have to

### DIFF
--- a/src/commands/pack.js
+++ b/src/commands/pack.js
@@ -21,12 +21,18 @@ const ENV = process.env.NODE_ENV || 'production';
 const PORT = process.env.PORT || 3000;
 
 function deleteDistributionFolder() {
-  return new Promise((resolve, reject) => {
-    console.log(
-      `${delimiter}: Deleting previously generated distribution folder...`
-    );
-    rimraf(path.resolve('dist'), (err) => err ? reject(err) : resolve());
-  });
+  if (ENV === 'production') {
+    return new Promise((resolve, reject) => {
+      console.log(
+        `${delimiter}: Deleting previously generated distribution folder...`
+      );
+      rimraf(path.resolve('dist'), (err) => err ? reject(err) : resolve());
+    });
+  } else {
+    // in dev mode, all resources are compiled and served from memory by
+    // webpack-dev-server so there is no reason to delete the dist folder
+    return Promise.resolve();
+  }
 }
 
 function runDevServer(compiler) {


### PR DESCRIPTION
Irritatingly, the dist folder gets deleted every time you run pack in dev mode even though the dev mode runs the code entirely out of memory and does not even use the on-disk dist folder.  This pull request will only delete it if you are in production mode.