### PR TITLE
fix(issue#34): Make check command lint also '.jsx' files

### DIFF
--- a/src/commands/check.js
+++ b/src/commands/check.js
@@ -39,7 +39,7 @@ function runJsLint() {
         resolve();
       }
     });
-    eslintChild.send('**/*.js');
+    eslintChild.send('**/*.{js,jsx}');
   });
 }
 


### PR DESCRIPTION

@alansouzati this is the fix for the _check command_ issue #34

**The Symptoms** 😷 

`.jsx` files not being verified by eslint when running `npm test` command.

**The Fix** 💊 

The pattern string send to _eslint_ was modified to match both `.js` and `.jsx` files.