### PR TITLE
update templates to grommet 1.9.0, add DXC Theme to cli options

### DIFF
--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -24,7 +24,8 @@ export const themes = {
   grommet: 'grommet/scss/vanilla/index',
   hpe: 'grommet/scss/hpe/index',
   aruba: 'grommet/scss/aruba/index',
-  hpinc: 'grommet/scss/hpinc/index'
+  hpinc: 'grommet/scss/hpinc/index',
+  dxc: 'grommet/scss/dxc/index'
 };
 
 export function capitalize(str) {

--- a/templates/app/package.json
+++ b/templates/app/package.json
@@ -18,7 +18,7 @@
     "compression": "^1.6.2",
     "cookie-parser": "^1.4.3",
     "express": "^4.14.0",
-    "grommet": "^1.3.4",
+    "grommet": "^1.9.0",
     "morgan": "^1.7.0",
     "path-to-regexp": "^1.7.0",
     "react": "^15.4.0",

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -11,7 +11,7 @@
     "dist": "cross-env NODE_ENV=production grommet pack"
   },
   "dependencies": {
-    "grommet": "^1.3.4",
+    "grommet": "^1.9.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0"
   },

--- a/templates/docs/package.json
+++ b/templates/docs/package.json
@@ -11,7 +11,7 @@
     "dist": "cross-env NODE_ENV=production grommet pack"
   },
   "dependencies": {
-    "grommet": "^1.3.4",
+    "grommet": "^1.9.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-router": "^3.0.0"


### PR DESCRIPTION

## Description
Enables the DXC Theme introduced in grommet 1.9.0 to be used with grommet cli.
(see [https://github.com/grommet/grommet/tree/v1.9.0/src/scss/dxc](https://github.com/grommet/grommet/tree/v1.9.0/src/scss/dxc))
This PR is motivated by my work with grommet and grommet-cli at DXC, since I am happy to use the new theme in my daily work.

## Testing
A website of each template has been created and briefly tested by user interaction.
No newly introduced bugs were discovered.
1.
- `grommet new --type basic --theme dxc basic-dxc-test`
- `yarn run dev`
2.
- `grommet new --type docs --theme dxc docs-dxc-test`
- `yarn run dev`
3.
- `grommet new --type app --theme dxc app-dxc-test`
- `yarn run dev-server &; yarn run dev` 

## Changes
- update grommet version in package.json for the app, docs and basic template
- add the dxc theme option to the cli utils

## Type of changes
- This introduces a new minor feature.
- This should be a non-breaking change.
