### PR TITLE
Update the templates package.json to patch for vulnerability in dependency

### DIFF
--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -24,7 +24,9 @@ export const themes = {
   grommet: 'grommet/scss/vanilla/index',
   hpe: 'grommet/scss/hpe/index',
   aruba: 'grommet/scss/aruba/index',
-  hpinc: 'grommet/scss/hpinc/index'
+  hpinc: 'grommet/scss/hpinc/index',
+  hpinc: 'grommet/scss/dxc/index'
+
 };
 
 export function capitalize(str) {

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -25,7 +25,7 @@ export const themes = {
   hpe: 'grommet/scss/hpe/index',
   aruba: 'grommet/scss/aruba/index',
   hpinc: 'grommet/scss/hpinc/index',
-  hpinc: 'grommet/scss/dxc/index'
+  dxc: 'grommet/scss/dxc/index'
 
 };
 

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -26,7 +26,6 @@ export const themes = {
   aruba: 'grommet/scss/aruba/index',
   hpinc: 'grommet/scss/hpinc/index',
   dxc: 'grommet/scss/dxc/index'
-
 };
 
 export function capitalize(str) {

--- a/templates/app/package.json
+++ b/templates/app/package.json
@@ -54,7 +54,7 @@
     "grommet-cli": "^5.0.0",
     "jest-cli": "^20.0.4",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.1.1",
+    "node-sass": "^4.9.0",
     "nodemon": "^1.11.0",
     "pre-commit": "^1.2.2",
     "react-dev-utils": "^0.4.2",

--- a/templates/basic/package.json
+++ b/templates/basic/package.json
@@ -36,7 +36,7 @@
     "grommet-cli": "^5.0.0",
     "jest-cli": "^20.0.4",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.1.1",
+    "node-sass": "^4.9.0",
     "pre-commit": "^1.2.2",
     "react-dev-utils": "^0.4.2",
     "react-test-renderer": "^15.4.1",

--- a/templates/docs/package.json
+++ b/templates/docs/package.json
@@ -40,7 +40,7 @@
     "grommet-cli": "^5.0.0",
     "jest-cli": "^20.0.4",
     "json-loader": "^0.5.4",
-    "node-sass": "^4.1.1",
+    "node-sass": "^4.9.0",
     "nodemon": "^1.11.0",
     "pre-commit": "^1.2.2",
     "react-dev-utils": "^0.4.2",


### PR DESCRIPTION
Update node-sass version to 4.9.0 since 4.1.1 depended on  a vulnerable version of hoek node module which suffers from a (MAID) vulnerability.  see https://nvd.nist.gov/vuln/detail/CVE-2018-3728 for more information.

Added dxc theme 